### PR TITLE
Move platform install dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV TERMINUS_CACHE_DIR ${WORKING_DIR}/.terminus/cache
 ENV SIMPLETEST_DB sqlite://tmp/site.sqlite
 
 RUN apk update && apk add --no-cache \
-    bash \
     curl \
     git \
     openssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p ${TERMINUS_PLUGINS_DIR} ${TERMINUS_CACHE_DIR} \
     && composer create-project -n -d ${TERMINUS_PLUGINS_DIR} pantheon-systems/terminus-build-tools-plugin:~1 \
     && touch ${HOME}/.bash_profile \
     && curl --silent --show-error https://platform.sh/cli/installer | php \
+    && mv ${HOME}/.platformsh ${WORKING_DIR} \
+    && ln -s ${WORKING_DIR}/.platformsh/bin/platform /usr/local/bin/platform \
     && chmod +x /scripts/build-tools-ci.sh
 
 WORKDIR /app


### PR DESCRIPTION
Moving .platformsh to the work directory so it lives in the same place as terminus and the rest of the tools. Also, getting rid of bash since we can install without it.