### PR TITLE
Add php gd and xdebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && apk add --no-cache \
     php7-ctype \
     php7-curl \
     php7-dom \
+    php7-gd \
     php7-iconv \
     php7-json \
     php7-mbstring \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk update && apk add --no-cache \
     php7-simplexml \
     php7-sqlite3 \
     php7-tokenizer \
+    php7-xdebug \
     php7-xml \
     php7-xmlwriter \
     php7-zlib \


### PR DESCRIPTION
The gd extension is required for Drupal 8.5. We need xdebug to create code coverage reports.